### PR TITLE
Duplication of SteeringWheel branch

### DIFF
--- a/spec/Cabin/Cabin.vspec
+++ b/spec/Cabin/Cabin.vspec
@@ -191,17 +191,3 @@
   type: sensor
   enum: ["undefined", "closed", "open", "closing", "opening", "stalled"]
   description: Roof status on convertible vehicles
-
-#
-# Steering Wheel Configuration
-#
-- SteeringWheel:
-  type: branch
-  description: Steering wheel configuration attributes
-
-- SteeringWheel.Position:
-  datatype: string
-  type: attribute
-  value: front_left
-  enum: ["front_left", "front_right"]
-  description: Position of the steering wheel inside the cabin

--- a/spec/Chassis/Chassis.vspec
+++ b/spec/Chassis/Chassis.vspec
@@ -175,6 +175,12 @@
   unit: percent
   description: Steering wheel column extension from dashboard. 0 = Closest to dashboard. 100 = Furthest from dashboard.
 
+- SteeringWheel.Position:
+  datatype: string
+  type: attribute
+  value: front_left
+  enum: ["front_left", "front_right"]
+  description: Position of the steering wheel on the left or right side of the vehicle.
 
 #
 # Accelerator


### PR DESCRIPTION
DataEntries of the SteeringWheels were spread over
cabin and chassis. Collecting them under one branch
improves readability.

Fixes: #59