### PR TITLE
Initial service-related Info

### DIFF
--- a/spec/Service/Service.vspec
+++ b/spec/Service/Service.vspec
@@ -1,0 +1,18 @@
+
+- ServiceNeeded:
+  datatype: boolean
+  type: sensor
+  description: True if the vehicle requires service
+
+- DistanceUntilNextService:
+  datatype: uint16
+  type: sensor
+  unit: km
+  description: Distance in km until next required (scheduled/predicted) service
+
+- TimeToNextService:
+  datatype: uint32
+  type: sensor
+  unit: s
+  description: Time in seconds until next required (scheduled/predicted) service
+  

--- a/spec/VehicleSignalSpecification.vspec
+++ b/spec/VehicleSignalSpecification.vspec
@@ -209,3 +209,12 @@
 # Driver branch created above and will include Occupant attributes
 
 #include Driver/Driver.vspec Vehicle.Driver
+
+
+#
+# The service branch contains service and (scheduled)maintenance information
+#
+- Vehicle.Service:
+  type: branch
+  description: Service and maintenance releated datapoints.
+#include Service/Service.vspec Vehicle.Service


### PR DESCRIPTION
This adds support for points 7, 8, and 9 of

https://github.com/GENIVI/vehicle_signal_specification/issues/180

Question is, which of those

"15." Low Oil Indicator
"17." Diesel Additive Range
"18."  Diesel Additive Status (Low Indicator) 
"19." Power Steering Warning Lamp
"21."  Airbag Warning Lamp
"22." Coolant Temperature High Warning
"25." Distance until Engine Oil Service
"26." Brake Fluid Level Low Warning |  *already in* Vehicle.Chassis.Axis.Wheel.Brake.FluidLevelLow | -
"28." Remaining Brake Fluid Life 
"29."  Distance until Brake Service 
"30"  Due Date for Brake Fluid Change  What is the difference to 28?"
"31." Oil Pressure Warning Lamp 
"32." Time until next Required Oil Change | TBD | -"
"33." Tyre pressure warning  *already in*  Vehcile.Chassis.Axis.Wheel.Tire.PressureLow | -
"34." Oil Temperature High Warning 
"35." Windshield Wiper Fluid Level

We should also put here, and which one to hide deep in the tree

@dakrbo 
