### PR TITLE
Extending GNSS data

### DIFF
--- a/spec/Vehicle/Vehicle.vspec
+++ b/spec/Vehicle/Vehicle.vspec
@@ -370,7 +370,7 @@ CurrentLocation.Latitude:
   min: -90
   max: 90
   unit: degrees
-  description: Current latitude of vehicle according to WGS 84.
+  description: Current latitude of vehicle according to WGS 84, as measured at position of GNSS receiver antenna.
 
 CurrentLocation.Longitude:
   datatype: double
@@ -378,7 +378,7 @@ CurrentLocation.Longitude:
   min: -180
   max: 180
   unit: degrees
-  description: Current longitude of vehicle according to WGS 84.
+  description: Current longitude of vehicle according to WGS 84, as measured at position of GNSS receiver antenna.
 
 CurrentLocation.Heading:
   datatype: double
@@ -399,10 +399,59 @@ CurrentLocation.Altitude:
   datatype: double
   type: sensor
   unit: m
-  description: Current altitude relative to WGS 84 reference ellipsoid.
+  description: Current altitude relative to WGS 84 reference ellipsoid, as measured at position of GNSS receiver antenna.
 
 CurrentLocation.VerticalAccuracy:
   datatype: double
   type: sensor
   unit: m
   description: Accuracy of altitude.
+
+CurrentLocation.GNSSReceiver:
+  type: branch
+  description: Information on the GNSS receiver used for determining current location.
+
+CurrentLocation.GNSSReceiver.FixType:
+  datatype: string
+  type: sensor
+  allowed: ['NONE', 
+            'TWO_D',
+            'TWO_D_SATELLITE_BASED_AUGMENTATION',
+            'TWO_D_GROUND_BASED_AUGMENTATION',
+            'TWO_D_SATELLITE_AND_GROUND_BASED_AUGMENTATION',
+            'THREE_D',
+            'THREE_D_SATELLITE_BASED_AUGMENTATION',
+            'THREE_D_GROUND_BASED_AUGMENTATION',
+            'THREE_D_SATELLITE_AND_GROUND_BASED_AUGMENTATION']
+  description: Fix status of GNSS receiver.
+
+CurrentLocation.GNSSReceiver.MountingPosition:
+  type: branch
+  description: Mounting position of GNSS receiver antenna relative to vehicle coordinate system.
+               Axis definitions according to ISO 8855. Origin at center of (first) rear axle.
+
+CurrentLocation.GNSSReceiver.MountingPosition.X:
+  datatype: int16
+  type: attribute
+  unit: mm
+  description: Mounting position of GNSS receiver antenna relative to vehicle coordinate system.
+               Axis definitions according to ISO 8855. Origin at center of (first) rear axle.
+               Positive values = forward of rear axle. Negative values = backward of rear axle.
+
+CurrentLocation.GNSSReceiver.MountingPosition.Y:
+  datatype: int16
+  type: attribute
+  unit: mm
+  description: Mounting position of GNSS receiver antenna relative to vehicle coordinate system.
+               Axis definitions according to ISO 8855. Origin at center of (first) rear axle.
+               Positive values = left of origin. Negative values = right of origin.
+               Left/Right is as seen from driver perspective, i.e. by a person looking forward.
+               
+CurrentLocation.GNSSReceiver.MountingPosition.Z:
+  datatype: int16
+  type: attribute
+  unit: mm
+  description: Mounting position of GNSS receiver on Z-axis.
+               Axis definitions according to ISO 8855. Origin at center of (first) rear axle.
+               Positive values = above center of rear axle. Negative values = below center of rear axle.
+               


### PR DESCRIPTION
Vehicles typically report position related to actual position of GNSS receiver.
In some cases it is necessary to know where the GNSS receiver is located.