### PR TITLE
Adding signal for user initiated emergency braking

### DIFF
--- a/spec/Chassis/Chassis.vspec
+++ b/spec/Chassis/Chassis.vspec
@@ -178,3 +178,11 @@ Brake.PedalPosition:
   unit: percent
   description: Brake pedal position as percent. 0 = Not depressed. 100 = Fully depressed.
 
+Brake.IsEmergencyBraking:
+  datatype: boolean
+  type: sensor
+  description: Indicates if emergency braking initiated by driver is detected.
+               True = Emergency braking detected. False  = Emergency braking not detected.
+  comment: Detection of emergency braking can trigger Emergency Brake Assist (EBA) to engage.
+  
+


### PR DESCRIPTION
This corresponds to that the vehicle detects that pressure or change of pressure
on brake pedal indicates that driver is emergency braking.